### PR TITLE
fix rich link preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <meta property="og:title" content="Shubham Agrawal">
   <meta property="og:description"
     content="My thoughts and ramblings about adventures in software development and entreprenuership.">
-  <meta property="og:image" content="https://raw.githubusercontent.com/shubh261096/portfolio/master/profile.png">
+  <meta property="og:image:secure_url" content="https://raw.githubusercontent.com/shubh261096/portfolio/master/profile.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:type" content="website">


### PR DESCRIPTION
https urls need to have extra metadata to display secure images in the stack, edited the open graph image url for the same. 

see this for reference: https://ogp.me/#structured